### PR TITLE
Feature/save scene data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ This is a work in progress.
 1. No trail when moving to a grid coord y < grid.size
 1. tokensplat mask alignment is slightly off
 1. sometimes tokensplats don't appear on damage (also on death?)
+1. ux - enter on adv config just closes doesnot save

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is a work in progress.
 1. thank vance and skimble on release
 1. use token velocity for direction?
 1. i18n
+1. Are both filters needed to get a sprite mask
 
 ## Bugs
 1. No trail when moving to a grid coord y < grid.size

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This is a work in progress.
 1. implement Tile pool to reuse tiles instead of creating new.
 1. thank vance and skimble on release
 1. use token velocity for direction?
+1. i18n
 
 ## Bugs
 1. No trail when moving to a grid coord y < grid.size

--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ This is a work in progress.
 1. tokensplat mask alignment is slightly off
 1. sometimes tokensplats don't appear on damage (also on death?)
 1. ux - enter on adv config just closes doesnot save
+1. reloading splats deletes the latest splat?

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "blood-n-guts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Spray your dungeons with blood! A module for FoundryVTT",
   "author": "edzillion",
   "license": "",

--- a/src/blood-n-guts.ts
+++ b/src/blood-n-guts.ts
@@ -129,7 +129,7 @@ Hooks.on('updateToken', async (scene, tokenData, changes, options, uid) => {
   if (!token) log(LogLevel.ERROR, 'updateToken token not found!');
 
   await checkForMovement(token, changes);
-  //checkForDamage(token, changes.actorData);
+  checkForDamage(token, changes.actorData);
   saveTokenState(token);
 });
 
@@ -550,9 +550,9 @@ const generateFloorSplats = (token: Token, font: SplatFont, size: number, densit
 
   const { offset, width, height } = alignSplatsGetOffsetAndDimensions(splatSaveObj.splats);
 
-  splatSaveObj.x = offset.x + token.center.x;
-  splatSaveObj.y = offset.y + token.center.y;
   splatSaveObj.offset = offset;
+  splatSaveObj.x = offset.x;
+  splatSaveObj.y = offset.y;
 
   const maxDistance = Math.max(width, height);
   const sight = computeSightFromPoint(token.center, maxDistance);

--- a/src/blood-n-guts.ts
+++ b/src/blood-n-guts.ts
@@ -22,6 +22,7 @@ import {
   lookupTokenBloodColor,
   computeSightFromPoint,
   drawDebugRect,
+  drawDebugRect2,
   randomBoxMuller,
   getDirectionNrml,
   alignSplatsAndGetOffset1,
@@ -557,7 +558,7 @@ const generateFloorSplats = (token: Token, font: SplatFont, size: number, densit
   const sight = computeSightFromPoint(token.center, maxDistance);
 
   splatSaveObj.maskPolygon = sight;
-  drawSplat(splatSaveObj);
+  drawSplat(splatSaveObj, token);
 };
 
 const generateTokenSplats = (token: Token, font: SplatFont, size: number, density: number) => {
@@ -706,19 +707,19 @@ const generateTrailSplats = (token: Token, font: SplatFont, size: number, densit
   log(LogLevel.DEBUG, 'generateTrailSplats splatSaveObj.splats', splatSaveObj.splats);
 
   const { offset, width, height } = alignSplatsGetOffsetAndDimensions(splatSaveObj.splats);
-
+  console.log(offset, width, height);
   splatSaveObj.offset = offset;
-  splatSaveObj.x = offset.x += token.center.x;
-  splatSaveObj.y = offset.y += token.center.y;
+  splatSaveObj.x = offset.x;
+  splatSaveObj.y = offset.y;
 
   const maxDistance = Math.max(width, height);
   const sight = computeSightFromPoint(token.center, maxDistance);
   splatSaveObj.maskPolygon = sight;
 
-  drawSplat(splatSaveObj);
+  drawSplat(splatSaveObj, token, width, height);
 };
 
-const drawSplat = (splatSaveObj) => {
+const drawSplat = (splatSaveObj, token, w?, h?) => {
   const splatsContainer = new PIXI.Container();
   const style = new PIXI.TextStyle(splatSaveObj.styleData);
 
@@ -734,17 +735,24 @@ const drawSplat = (splatSaveObj) => {
   sightMask.beginFill(1, 1);
   sightMask.drawPolygon(splatSaveObj.maskPolygon);
   sightMask.endFill();
-
   sightMask.x -= splatSaveObj.offset.x;
   sightMask.y -= splatSaveObj.offset.y;
+  //sightMask.visible = false;
   splatsContainer.addChild(sightMask);
-  //splatsContainer.mask = sightMask;
-  splatsContainer.x = splatSaveObj.x;
-  splatsContainer.y = splatSaveObj.y;
-  sightMask.x += splatSaveObj.x;
-  sightMask.y += splatSaveObj.y;
+  splatsContainer.mask = sightMask;
+
+  // sightMask.x += splatSaveObj.offset.x;
+  // sightMask.y += splatSaveObj.offset.y;
+  // sightMask.x -= splatSaveObj.offset.x;
+  // sightMask.y -= splatSaveObj.offset.y;
+  //splatsContainer.addChild(sightMask);
+  // //splatsContainer.mask = sightMask;
+  splatsContainer.x = splatSaveObj.x + token.center.x;
+  splatsContainer.y = splatSaveObj.y + token.center.y;
+  // sightMask.x += splatSaveObj.x;
+  // sightMask.y += splatSaveObj.y;
   //addToSplatPool(splatsContainer, style, sight);
   canvas.tiles.addChild(splatsContainer);
 
-  if (CONFIG.logLevel >= LogLevel.DEBUG) drawDebugRect(splatsContainer);
+  if (CONFIG.logLevel >= LogLevel.DEBUG) drawDebugRect2(splatsContainer.x, splatsContainer.y, w, h);
 };

--- a/src/blood-n-guts.ts
+++ b/src/blood-n-guts.ts
@@ -8,7 +8,7 @@
  */
 
 //CONFIG.debug.hooks = true;
-CONFIG.logLevel = 1;
+CONFIG.logLevel = 2;
 
 // Import JavaScript modules
 import { registerSettings } from './module/settings';
@@ -34,6 +34,7 @@ import { MODULE_ID } from './constants';
 const lastTokenState: Array<SaveObject> = [];
 const splatPool: Array<PIXI.Container> = [];
 const fadingSplatPool: Array<PIXI.Container> = [];
+let activeScene;
 
 (document as any).fonts.ready.then(() => {
   log(LogLevel.DEBUG, 'All fonts in use by visible text have loaded.');
@@ -92,6 +93,17 @@ Hooks.once('ready', () => {
 Hooks.on('createToken', (_scene, tokenData) => {
   const token = new Token(tokenData);
   saveTokenState(token);
+});
+
+Hooks.once('canvasInit', (canvas) => {
+  log(LogLevel.INFO, 'canvasInit', canvas);
+  if (canvas.scene.active) activeScene = canvas.scene;
+  //redraw containers?
+
+  const splatP = activeScene.getFlag(MODULE_ID, 'splatPool');
+  if (splatP) {
+    console.log(JSON.parse(splatP));
+  }
 });
 
 Hooks.once('canvasReady', () => {
@@ -445,5 +457,12 @@ const addToSplatPool = (container: PIXI.Container): void => {
     fadingSplatPool.push(fadingSplat);
   }
   splatPool.push(container);
+  saveSplatsToScene();
   log(LogLevel.DEBUG, `addToSplatPool splatPool:${splatPool.length}, fadingSplatPool:${fadingSplatPool.length}`);
+};
+
+const saveSplatsToScene = async () => {
+  //const sp = JSON.stringify(splatPool);
+  console.log(splatPool);
+  //activeScene.setFlag(MODULE_ID, 'splatPool', sp);
 };

--- a/src/blood-n-guts.ts
+++ b/src/blood-n-guts.ts
@@ -119,7 +119,7 @@ Hooks.once('canvasReady', () => {
     log(LogLevel.DEBUG, 'onloadingdone we have ' + fontFaceSetEvent.fontfaces.length + ' font faces loaded');
     const check = (document as any).fonts.check('1em splatter');
     log(LogLevel.DEBUG, 'splatter loaded? ' + check);
-
+    if (!check) return;
     const pool = activeScene.getFlag(MODULE_ID, 'splatPool');
     console.log('splatPool', pool);
     drawSceneSplats(pool);
@@ -325,10 +325,10 @@ const addToSplatPool = (splatContainer, splatSaveObj): void => {
 };
 
 const saveSceneSplats = async () => {
-  log(LogLevel.INFO, 'drawSceneSplats');
+  log(LogLevel.INFO, 'saveSceneSplats');
   const pool = splatPool.map((splat) => splat.save);
-  log(LogLevel.DEBUG, 'drawSceneSplats: pool', pool);
-  return activeScene.setFlag(MODULE_ID, 'splatPool', pool);
+  log(LogLevel.DEBUG, 'saveSceneSplats: pool', pool);
+  await activeScene.setFlag(MODULE_ID, 'splatPool', pool);
 };
 
 const drawSceneSplats = async (splatSaveObjects) => {

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -31,10 +31,13 @@ interface SplatSaveObject {
   styleData: any;
   splats: Array<Splat>;
   maskPolygon: Array<number>;
+  offset: PIXI.Point;
 }
 
 interface Splat {
   glyph: string;
   x: number;
   y: number;
+  width: number;
+  height: number;
 }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -14,10 +14,24 @@ interface ViolenceLevel {
   splatPoolSize: number;
 }
 
-interface SaveObject {
+interface TokenSaveObject {
   x: number;
   y: number;
   centerX: number;
   centerY: number;
   hp: number;
+}
+
+interface SplatSaveObject {
+  x: number;
+  y: number;
+  styleData: any;
+  splats: Array<Splat>;
+  maskPolygon: Array<number>;
+}
+
+interface Splat {
+  glyph: string;
+  x: number;
+  y: number;
 }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -30,8 +30,10 @@ interface SplatSaveObject {
   y: number;
   styleData: any;
   splats: Array<Splat>;
-  maskPolygon: Array<number>;
   offset: PIXI.Point;
+  maskPolygon?: Array<number>;
+  imgPath?: string;
+  tokenId?: string;
 }
 
 interface Splat {

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -21,7 +21,10 @@ interface TokenSaveObject {
   centerY: number;
   hp: number;
 }
-
+interface SplatPoolObject {
+  save: SplatSaveObject;
+  splatContainer: PIXI.Container;
+}
 interface SplatSaveObject {
   x: number;
   y: number;

--- a/src/module.json
+++ b/src/module.json
@@ -3,7 +3,7 @@
   "title": "Blood n Guts - An Example FVTT Module",
   "description": "A simple module created as a demo for working in the Foundry Virtual Tabletop framework.",
   "author": "edzillion",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "minimumCoreVersion": "0.0.1",
   "esmodules": ["./blood-n-guts.js"],
   "styles": ["./blood-n-guts.css"]  

--- a/src/module/advancedConfig.ts
+++ b/src/module/advancedConfig.ts
@@ -3,6 +3,8 @@ import { MODULE_ID } from '../constants';
 import * as violenceLevelSettings from '../data/violenceLevelSettings';
 import * as splatFonts from '../data/splatFonts';
 
+let activeScene;
+
 export class AdvancedConfig extends FormApplication {
   font: SplatFont;
   allAsciiCharacters: string;
@@ -11,6 +13,7 @@ export class AdvancedConfig extends FormApplication {
     super(object, options);
     game.settings.sheet.close();
     game.users.apps.push(this);
+    if (canvas.scene.active) activeScene = canvas.scene;
   }
 
   static get defaultOptions(): FormApplicationOptions {
@@ -48,6 +51,12 @@ export class AdvancedConfig extends FormApplication {
 
   activateListeners(html) {
     super.activateListeners(html);
+
+    const wipeButton = html.find('.advanced-config-wipe-pool');
+    wipeButton.click((e) => {
+      activeScene.setFlag(MODULE_ID, 'splatPool', null);
+      this.close();
+    });
   }
 
   async _updateObject(event, formData) {

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -10,22 +10,10 @@ export const alignSplatsAndGetOffset = (splats: Array<PIXI.Text>): PIXI.Point =>
   let highestY = 0;
   for (let i = 0; i < splats.length; i++) {
     const txt = splats[i];
-    if (txt.x < lowestX) {
-      console.log('lowestX', txt.x);
-      lowestX = txt.x;
-    }
-    if (txt.y < lowestY) {
-      console.log('lowestY', txt.y);
-      lowestY = txt.y;
-    }
-    if (txt.x + txt.width > highestX) {
-      console.log('highestX', txt.x);
-      highestX = txt.x + txt.width;
-    }
-    if (txt.y + txt.height > highestY) {
-      console.log('highestY', txt.y);
-      highestY = txt.y + txt.height;
-    }
+    if (txt.x < lowestX) lowestX = txt.x;
+    if (txt.y < lowestY) lowestY = txt.y;
+    if (txt.x + txt.width > highestX) highestX = txt.x + txt.width;
+    if (txt.y + txt.height > highestY) highestY = txt.y + txt.height;
   }
   for (let j = 0; j < splats.length; j++) {
     const t = splats[j];
@@ -58,7 +46,6 @@ export const computeSightFromPoint = (origin: Point, range: number): [number] =>
   let lowestY = canvas.dimensions.sceneHeight;
 
   for (let i = 0; i < sight.fov.points.length; i += 2) {
-    console.log('currentLowestX:' + lowestX, 'currentLowestY:' + lowestY);
     lowestX = sight.fov.points[i] < lowestX ? sight.fov.points[i] : lowestX;
     lowestY = sight.fov.points[i + 1] < lowestY ? sight.fov.points[i + 1] : lowestY;
   }

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -3,7 +3,7 @@ import * as bloodColorSettings from '../data/bloodColorSettings';
 import { colors, getRGBA } from './colors';
 import { MODULE_ID } from '../constants';
 
-export const alignSplatsAndGetOffset = (splats: Array<PIXI.Text>): PIXI.Point => {
+export const alignSplatsAndGetOffset1 = (splats: Array<PIXI.Text>): PIXI.Point => {
   let lowestX = canvas.dimensions.sceneWidth;
   let lowestY = canvas.dimensions.sceneHeight;
   let highestX = 0;
@@ -21,6 +21,30 @@ export const alignSplatsAndGetOffset = (splats: Array<PIXI.Text>): PIXI.Point =>
     t.y -= lowestY;
   }
   return new PIXI.Point(lowestX, lowestY);
+};
+
+export const alignSplatsGetOffsetAndDimensions = (splats: Array<Splat>) => {
+  let lowestX = canvas.dimensions.sceneWidth;
+  let lowestY = canvas.dimensions.sceneHeight;
+  let highestX = 0;
+  let highestY = 0;
+  for (let i = 0; i < splats.length; i++) {
+    const splat = splats[i];
+    if (splat.x < lowestX) lowestX = splat.x;
+    if (splat.y < lowestY) lowestY = splat.y;
+    if (splat.x + splat.width > highestX) highestX = splat.x + splat.width;
+    if (splat.y + splat.height > highestY) highestY = splat.y + splat.height;
+  }
+  for (let j = 0; j < splats.length; j++) {
+    const t = splats[j];
+    t.x -= lowestX;
+    t.y -= lowestY;
+  }
+  return {
+    offset: new PIXI.Point(lowestX, lowestY),
+    width: highestX - lowestX,
+    height: highestY - lowestY,
+  };
 };
 
 export const computeSightFromPoint = (origin: Point, range: number): [number] => {

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -150,6 +150,12 @@ export const drawDebugRect = (container: PIXI.Container, width = 2, color = 0xff
   log(LogLevel.DEBUG, 'drawDebugRect: ', container);
 };
 
+export const drawDebugRect2 = (x, y, w, h): void => {
+  const rect = new PIXI.Graphics();
+  rect.lineStyle(2, 0xff0000).drawRect(x, y, w, h);
+  canvas.drawings.addChild(rect);
+};
+
 export const getDirectionNrml = (lastPosition: Point, changes: any): PIXI.Point => {
   let x = Number(changes.x > lastPosition.x);
   let y = Number(changes.y > lastPosition.y);

--- a/src/templates/advanced-config.html
+++ b/src/templates/advanced-config.html
@@ -92,6 +92,7 @@
       </div>
       <p class="notes">The max amount of splats to display at once before reuse</p>
     </div>
+      <button type="button" class="advanced-config-wipe-pool" name="wipe-pool"><i class="fas fa-trash-alt"></i>Wipe Pool</button>
       <button type="submit" class="advanced-config-submit" name="submit"><i class="fas fa-dice"></i>Submit</button>
   </div>
 </form>


### PR DESCRIPTION
Pretty huge changes here. 

Splats are now saved via scene flags. This is achieved by implementing a `splatPool` which is an Array of SplatPoolObjects like so:

```js
{
  save: saveSplatObj,
  container: splatContainer
}
```
This keeps track of all splatContainers in the scene along with a save object that is periodically saved. This can be retrieved displayed and reloaded into the pool on load, as the save objects contain all the relevant info.

```js
interface SplatPoolObject {
  save: SplatSaveObject;
  splatContainer: PIXI.Container;
}

interface SplatSaveObject {
  x: number;
  y: number;
  styleData: any;
  splats: Array<Splat>;
  offset: PIXI.Point;
  maskPolygon?: Array<number>;
  tokenId?: string;
}

interface Splat {
  glyph: string;
  x: number;
  y: number;
  width: number;
  height: number;
}
```