### PR TITLE
Add support for 'gurps' system

### DIFF
--- a/src/data/systems.ts
+++ b/src/data/systems.ts
@@ -258,6 +258,25 @@ export default {
       if (creatureType) return creatureType.toLowerCase();
     },
   },
+  gurps: {
+    id: 'gurps',
+    currentHP: (token) => token.actor.data.data.HP.value,
+    maxHP: (token) => token.actor.data.data.HP.max,
+    currentHPChange: (changes: Record<string, any>): number => changes?.actorData?.data?.HP?.value,
+    maxHPChange: (changes: Record<string, any>): number => changes?.actorData?.data?.HP?.max,
+    creatureType: (token: Token, bloodColorSettings?: Record<string, string>): string | void => {
+      let creatureType: string;
+      // No races or creatureTypes in GURPS apparently
+      // Instead just search through the name for possible creature type
+      const wordsInName: Array<string> = token.actor.data.name.replace(',', ' ').split(' ');
+      for (let i = 0; i < wordsInName.length; i++) {
+        const word = wordsInName[i].toLowerCase();
+        if (bloodColorSettings[word]) creatureType = word;
+      }
+      log(LogLevel.DEBUG, 'creatureType gurps: ', token.name, creatureType);
+      if (creatureType) return creatureType.toLowerCase();
+    },
+  },
   D35E: {
     id: 'D35E',
     supportedTypes: ['character', 'npc'],

--- a/src/data/systems.ts
+++ b/src/data/systems.ts
@@ -267,11 +267,14 @@ export default {
     creatureType: (token: Token, bloodColorSettings?: Record<string, string>): string | void => {
       let creatureType: string;
       // No races or creatureTypes in GURPS apparently
-      // Instead just search through the name for possible creature type
-      const wordsInName: Array<string> = token.actor.data.name.replace(',', ' ').split(' ');
-      for (let i = 0; i < wordsInName.length; i++) {
-        const word = wordsInName[i].toLowerCase();
-        if (bloodColorSettings[word]) creatureType = word;
+      creatureType = token.actor.data.data.additionalresources.bloodtype;
+      if (!bloodColorSettings[creatureType]) {
+        // Instead just search through the name for possible creature type
+        const wordsInName: Array<string> = token.actor.data.name.replace(',', ' ').split(' ');
+        for (let i = 0; i < wordsInName.length; i++) {
+          const word = wordsInName[i].toLowerCase();
+          if (bloodColorSettings[word]) creatureType = word;
+        }
       }
       log(LogLevel.DEBUG, 'creatureType gurps: ', token.name, creatureType);
       if (creatureType) return creatureType.toLowerCase();


### PR DESCRIPTION
GURPS Actors can go below 0 HP and still be standing.    They are only assured to be dead at -5 * HP.max.  I don't know if that makes a difference.
Our system only has 1 actor type 'character', and no 'types'.

These are the 'types', correct?
  abberation: '#0505af',
  beast: 'blood',
  dwarf: 'blood',
  humanoid: 'blood',
  giant: 'blood',
  swarm: 'blood',
  celestial: '#dc9e06',
  construct: '#251a13',
  dragon: 'name',
  elemental: '#0fe9e6',
  elf: 'silver',
  fey: '#1e824c',
  plant: '#04db41',
  'half-elf': '#e96060',
  mech: '#251a13',
  monstrosity: '#4e009a',
  ooze: 'name',
  undead: '#ece6ff',

Will this list change?   If not, I could add it as a pulldown menu for our characters.   I've added code to check for a 'bloodtype' in our actor (which doesn't exists yet) and then fallback to the name checking.     FYI, token.actor.data.data.additionalresources will always exist (it is defined in the template.json).

Hmmm... I wonder how I can access that static in our code... I've never don't cross-module work ;-)    But it would be nice if I could just read it directly to make a pulldown menu from it.