### PR TITLE
Fixed pf1e support for NPC tokens with no classes

### DIFF
--- a/src/data/systems.ts
+++ b/src/data/systems.ts
@@ -77,10 +77,10 @@ export default {
       let creatureType: string;
       if (actorType === 'character') {
         // @ts-expect-error bad definition
-        creatureType = token.actor.data.items.find((i) => i.type === 'race').name;
+        creatureType = token.actor.data.items.find((i) => i.type === 'race')?.name ?? '';
       } else if (actorType === 'npc') {
         // @ts-expect-error bad definition
-        creatureType = token.actor.data.items.find((i) => i.type === 'class').name;
+        creatureType = token.actor.data.items.find((i) => i.type === 'class')?.name ?? '';
       }
 
       log(LogLevel.DEBUG, 'creatureType pf1: ', token.name, actorType, creatureType);


### PR DESCRIPTION
I also threw the same check on PC tokens. Even though it's super unlikely, it's not guaranteed that a PC will have a race defined.

I tested locally but made the changes in githubs web editor.